### PR TITLE
Randomize history API endpoints

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,7 +1,12 @@
 {
   "watchInterval": 500,
   "eosApi": "http://mainnet.eoscalgary.io/v1",
-  "eosHistoryApi": "http://api.cypherglass.com/v1",
+  "eosHistoryApi": [
+    "https://api.cypherglass.com/v1",
+    "http://fn.eossweden.se/v1",
+    "http://api.hkeos.com/v1",
+    "https://api1.eosasia.one/v1"
+  ],
   "apiTimeout": 3000,
   "initialBlock": 1293913,
   "accounts": {

--- a/lib/eosApi.js
+++ b/lib/eosApi.js
@@ -18,9 +18,9 @@ const getBlockInfo = blockNum => {
 }
 
 const getTransaction = id => {
-  randomAPI = historyApiUrl[Math.floor(Math.random()*historyApiUrl.length)]
+  randomApi = historyApiUrl[Math.floor(Math.random()*historyApiUrl.length)]
   return axios.post(
-    randomAPI + '/history/get_transaction',
+    randomApi + '/history/get_transaction',
     {id},
     {timeout}
   ).then(res => res.data)

--- a/lib/eosApi.js
+++ b/lib/eosApi.js
@@ -18,8 +18,9 @@ const getBlockInfo = blockNum => {
 }
 
 const getTransaction = id => {
+  randomAPI = historyApiUrl[Math.floor(Math.random()*historyApiUrl.length)]
   return axios.post(
-    historyApiUrl + '/history/get_transaction',
+    randomAPI + '/history/get_transaction',
     {id},
     {timeout}
   ).then(res => res.data)


### PR DESCRIPTION
This seems to get me past the random 500 errors. It also might be good for distributing load across the BP in general. 

Do you happen to know which BPs which support history API? I've been finding them by trial and error.

Fixes #1